### PR TITLE
fix(theme): full text search doesn't support partial search (close: #77)

### DIFF
--- a/packages/vuepress-theme-vt/plugins/fulltext-search/services/flexsearchSvc.js
+++ b/packages/vuepress-theme-vt/plugins/fulltext-search/services/flexsearchSvc.js
@@ -19,7 +19,7 @@ export default {
     );
     const indexSettings = {
       encode: options.encode || "simple",
-      tokenize: options.tokenize || "forward",
+      tokenize: options.tokenize || "reverse",
       split: options.split || /\W+/,
       async: true,
       doc: {


### PR DESCRIPTION
Using [reverse](https://github.com/nextapps-de/flexsearch#tokenizer-prefix-search) tokenizer, support incrementally index words in both directions.

Snapshot:

![image](https://user-images.githubusercontent.com/23133919/200303419-62d1b7ce-2ab6-416f-9790-7c9a9e5e39d2.png)
