### PR TITLE
feat: refine theme style

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "cSpell.words": [
+        "darkmode"
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@
 </p>
 
 <p align="center">
-An <b>Elegant</b> VuePress Theme,<br>
-inspired by <code>@vue/theme</code> .
+An <b>Elegant</b> VuePress Documentation Theme<br>
 </p>
 
 <p align="center">

--- a/packages/docs/docs/guide/index.md
+++ b/packages/docs/docs/guide/index.md
@@ -6,9 +6,9 @@
 
 I made this theme to combine eXperience of `@vue/theme` and [current huge VuePress ecosystem](https://github.com/vuepress/awesome-vuepress/), also introducing some built-in features like **full-text search**, **i18n** etc.
 
-## Features
+## Features2
 
-- [**Compatibility**](./migration.md): fully compatible with [VuePress's Default Theme](https://vuepress.vuejs.org/theme/default-theme-config.md).
+- [**Compatibility2**](./migration.md): fully compatible with [VuePress's Default Theme](https://vuepress.vuejs.org/theme/default-theme-config.html).
 - [**Full-text search**](./search.md): No server dependencies, distinguishing locales.
 - [Dark Mode](./dark-mode.md)
 - [TypeScript Support](./configuration.md)

--- a/packages/docs/docs/guide/index.md
+++ b/packages/docs/docs/guide/index.md
@@ -6,9 +6,9 @@
 
 I made this theme to combine eXperience of `@vue/theme` and [current huge VuePress ecosystem](https://github.com/vuepress/awesome-vuepress/), also introducing some built-in features like **full-text search**, **i18n** etc.
 
-## Features2
+## Features
 
-- [**Compatibility2**](./migration.md): fully compatible with [VuePress's Default Theme](https://vuepress.vuejs.org/theme/default-theme-config.html).
+- [**Compatibility**](./migration.md): fully compatible with [VuePress's Default Theme](https://vuepress.vuejs.org/theme/default-theme-config.html).
 - [**Full-text search**](./search.md): No server dependencies, distinguishing locales.
 - [Dark Mode](./dark-mode.md)
 - [TypeScript Support](./configuration.md)

--- a/packages/vuepress-theme-vt/components/API.vue
+++ b/packages/vuepress-theme-vt/components/API.vue
@@ -150,7 +150,6 @@ h2 {
 
 h3 {
   letter-spacing: -0.01em;
-  color: var(--c-brand);
   font-size: 18px;
   margin-bottom: 1em;
   transition: color 0.5s;
@@ -244,7 +243,7 @@ h1:hover .header-anchor, h1:focus .header-anchor, h2:hover .header-anchor, h2:fo
 }
 
 .api-groups a:hover {
-  color: var(--c-brand);
+  color: var(--vp-c-link);
   transition: none;
 }
 

--- a/packages/vuepress-theme-vt/components/API.vue
+++ b/packages/vuepress-theme-vt/components/API.vue
@@ -150,6 +150,7 @@ h2 {
 
 h3 {
   letter-spacing: -0.01em;
+  color: var(--c-brand);
   font-size: 18px;
   margin-bottom: 1em;
   transition: color 0.5s;
@@ -243,7 +244,7 @@ h1:hover .header-anchor, h1:focus .header-anchor, h2:hover .header-anchor, h2:fo
 }
 
 .api-groups a:hover {
-  color: var(--vp-c-link);
+  color: var(--c-brand);
   transition: none;
 }
 

--- a/packages/vuepress-theme-vt/components/API.vue
+++ b/packages/vuepress-theme-vt/components/API.vue
@@ -150,7 +150,7 @@ h2 {
 
 h3 {
   letter-spacing: -0.01em;
-  color: var(--c-brand);
+  color: var(--vp-c-brand);
   font-size: 18px;
   margin-bottom: 1em;
   transition: color 0.5s;
@@ -244,7 +244,7 @@ h1:hover .header-anchor, h1:focus .header-anchor, h2:hover .header-anchor, h2:fo
 }
 
 .api-groups a:hover {
-  color: var(--c-brand);
+  color: var(--vp-c-brand);
   transition: none;
 }
 

--- a/packages/vuepress-theme-vt/components/AlgoliaSearchBox.vue
+++ b/packages/vuepress-theme-vt/components/AlgoliaSearchBox.vue
@@ -128,7 +128,7 @@ export default {
       .algolia-docsearch-suggestion--category-header {
         padding: 5px 10px;
         margin-top: 0;
-        background: var(--c-brand);;
+        background: var(--vp-c-brand);;
         color: #fff;
         font-weight: 500;
 

--- a/packages/vuepress-theme-vt/components/DropdownLink.vue
+++ b/packages/vuepress-theme-vt/components/DropdownLink.vue
@@ -162,7 +162,7 @@ export default {
 
     font-size inherit {
       &:hover {
-        color: var(--c-brand);
+        color: var(--vp-c-link);
       }
     }
   }
@@ -198,12 +198,8 @@ export default {
         margin-bottom: 0;
         padding: 0 1.5rem 0 1.25rem;
 
-        &:hover {
-          color: var(--c-brand);
-        }
-
-        &.router-link-active {
-          color: var(--c-brand);
+        &:hover, &.router-link-active {
+          color: var(--vp-c-link);
         }
       }
 

--- a/packages/vuepress-theme-vt/components/DropdownLink.vue
+++ b/packages/vuepress-theme-vt/components/DropdownLink.vue
@@ -162,7 +162,7 @@ export default {
 
     font-size inherit {
       &:hover {
-        color: var(--vp-c-link);
+        color: var(--c-brand);
       }
     }
   }
@@ -198,8 +198,12 @@ export default {
         margin-bottom: 0;
         padding: 0 1.5rem 0 1.25rem;
 
-        &:hover, &.router-link-active {
-          color: var(--vp-c-link);
+        &:hover {
+          color: var(--c-brand);
+        }
+
+        &.router-link-active {
+          color: var(--c-brand);
         }
       }
 

--- a/packages/vuepress-theme-vt/components/DropdownLink.vue
+++ b/packages/vuepress-theme-vt/components/DropdownLink.vue
@@ -162,7 +162,7 @@ export default {
 
     font-size inherit {
       &:hover {
-        color: var(--c-brand);
+        color: var(--vp-c-brand);
       }
     }
   }
@@ -199,11 +199,11 @@ export default {
         padding: 0 1.5rem 0 1.25rem;
 
         &:hover {
-          color: var(--c-brand);
+          color: var(--vp-c-brand);
         }
 
         &.router-link-active {
-          color: var(--c-brand);
+          color: var(--vp-c-brand);
         }
       }
 

--- a/packages/vuepress-theme-vt/components/Home.vue
+++ b/packages/vuepress-theme-vt/components/Home.vue
@@ -161,7 +161,7 @@ section {
 
 .actions .action-link {
   font-weight: 500;
-  background-color: var(--c-brand);
+  background-color: var(--vp-c-brand);
   color: #fff;
   margin-right: 18px;
 }

--- a/packages/vuepress-theme-vt/components/Home.vue
+++ b/packages/vuepress-theme-vt/components/Home.vue
@@ -143,7 +143,7 @@ section {
 }
 
 .dark .heroText {
-  color: var(--c-brand-light);
+  color: var(--vp-c-brand-light);
   background: -webkit-linear-gradient(315deg, #42d392 25%, #647eff);
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
@@ -180,7 +180,7 @@ section {
 }
 
 .actions .action-link:hover {
-  background-color: var(--c-brand-dark);
+  background-color: var(--vp-c-brand-dark);
   transition-duration: 0.2s;
 }
 
@@ -189,7 +189,7 @@ section {
 }
 
 .dark .actions .action-link:hover {
-  background-color: var(--c-brand-light);
+  background-color: var(--vp-c-brand-light);
 }
 
 .actions .sub-action-link {

--- a/packages/vuepress-theme-vt/components/NavLinks.vue
+++ b/packages/vuepress-theme-vt/components/NavLinks.vue
@@ -222,7 +222,7 @@ function css(el, property) {
     color: inherit;
 
     &:hover, &.router-link-active {
-      color: var(--c-brand);
+      color: var(--vp-c-brand);
     }
   }
 
@@ -285,7 +285,7 @@ function css(el, property) {
 @media (min-width: $MQMobile) {
   .nav-links a {
     &:hover, &.router-link-active {
-      color: var(--c-brand);
+      color: var(--vp-c-brand);
 
       &::before {
         content: '';
@@ -305,7 +305,7 @@ function css(el, property) {
       margin-bottom: -2px;
 
       &::before {
-        background-color: var(--c-brand);
+        background-color: var(--vp-c-brand);
       }
     }
   }

--- a/packages/vuepress-theme-vt/components/NavLinks.vue
+++ b/packages/vuepress-theme-vt/components/NavLinks.vue
@@ -222,7 +222,7 @@ function css(el, property) {
     color: inherit;
 
     &:hover, &.router-link-active {
-      color: var(--c-brand);
+      color: var(--vp-c-link);
     }
   }
 
@@ -285,18 +285,7 @@ function css(el, property) {
 @media (min-width: $MQMobile) {
   .nav-links a {
     &:hover, &.router-link-active {
-      color: var(--c-brand);
-
-      &::before {
-        content: '';
-        position: absolute;
-        width: calc(100% + 30px);
-        height: 1px;
-        position: absolute;
-        bottom: -3px;
-        left: -15px;
-        transition: background-color 0.2s;
-      }
+      color: var(--vp-c-link);
     }
   }
 

--- a/packages/vuepress-theme-vt/components/NavLinks.vue
+++ b/packages/vuepress-theme-vt/components/NavLinks.vue
@@ -222,7 +222,7 @@ function css(el, property) {
     color: inherit;
 
     &:hover, &.router-link-active {
-      color: var(--vp-c-link);
+      color: var(--c-brand);
     }
   }
 
@@ -285,7 +285,18 @@ function css(el, property) {
 @media (min-width: $MQMobile) {
   .nav-links a {
     &:hover, &.router-link-active {
-      color: var(--vp-c-link);
+      color: var(--c-brand);
+
+      &::before {
+        content: '';
+        position: absolute;
+        width: calc(100% + 30px);
+        height: 1px;
+        position: absolute;
+        bottom: -3px;
+        left: -15px;
+        transition: background-color 0.2s;
+      }
     }
   }
 

--- a/packages/vuepress-theme-vt/components/PageNav.vue
+++ b/packages/vuepress-theme-vt/components/PageNav.vue
@@ -158,7 +158,7 @@ function flatten(items, res) {
     }
 
     &:hover {
-      border-color: var(--c-brand);
+      border-color: var(--vp-c-brand);
       transition: border-color 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
 
       & span {

--- a/packages/vuepress-theme-vt/components/SidebarGroup.vue
+++ b/packages/vuepress-theme-vt/components/SidebarGroup.vue
@@ -142,12 +142,12 @@ export default {
   &.clickable {
     &.active {
       font-weight: 500;
-      color: var(--c-brand);;
-      border-left-color: var(--c-brand);;
+      color: var(--vp-c-brand);;
+      border-left-color: var(--vp-c-brand);;
     }
 
     &:hover {
-      color: var(--c-brand);;
+      color: var(--vp-c-brand);;
     }
   }
 }

--- a/packages/vuepress-theme-vt/components/SidebarLink.vue
+++ b/packages/vuepress-theme-vt/components/SidebarLink.vue
@@ -132,11 +132,11 @@ a.sidebar-link {
   transition: color 0.3s;
 
   &:hover {
-    color: var(--c-brand);
+    color: var(--vp-c-brand);
   }
 
   &.active {
-    color: var(--c-brand);
+    color: var(--vp-c-brand);
   }
 
   .sidebar-group & {

--- a/packages/vuepress-theme-vt/components/SidebarLink.vue
+++ b/packages/vuepress-theme-vt/components/SidebarLink.vue
@@ -137,6 +137,7 @@ a.sidebar-link {
 
   &.active {
     color: var(--vp-c-brand);
+    font-weight: 500;
   }
 
   .sidebar-group & {

--- a/packages/vuepress-theme-vt/components/Toc.vue
+++ b/packages/vuepress-theme-vt/components/Toc.vue
@@ -189,17 +189,17 @@ export default {
     }
 
     &.active {
-      border-left-color: var(--c-brand);
+      border-left-color: var(--vp-c-brand);
 
       a {
-        color: var(--c-brand);
+        color: var(--vp-c-brand);
         font-weight: 500;
       }
     }
 
     &:hover {
       a {
-        color: var(--c-brand);
+        color: var(--vp-c-brand);
       }
     }
   }

--- a/packages/vuepress-theme-vt/global-components/Badge.vue
+++ b/packages/vuepress-theme-vt/global-components/Badge.vue
@@ -78,8 +78,8 @@ export default {
 .dark {
   .badge {
     &.tip, &.green {
-      color: var(--c-brand);
-      border: 1px solid var(--c-brand);
+      color: var(--vp-c-brand);
+      border: 1px solid var(--vp-c-brand);
     }
   }
 }

--- a/packages/vuepress-theme-vt/global-components/Details.vue
+++ b/packages/vuepress-theme-vt/global-components/Details.vue
@@ -8,7 +8,7 @@
 .pia-details {
   cursor: pointer;
   background-color: var(--vp-c-bg-soft);
-  border: 1px solid var(--c-brand-light);
+  border: 1px solid var(--vp-c-brand-light);
   padding: 20px 24px;
   border-radius: 8px;
 

--- a/packages/vuepress-theme-vt/global-components/Step.vue
+++ b/packages/vuepress-theme-vt/global-components/Step.vue
@@ -13,7 +13,7 @@ export default {
 };
 </script>
 
-<style>
+<style lang="stylus">
 .next-step {
   border: 1px solid var(--vp-c-bg-soft);
   background-color: var(--vp-c-bg-soft);
@@ -28,6 +28,10 @@ export default {
 .next-step:hover {
   border-color: var(--vp-c-brand);
   transition: border-color 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
+
+  .next-steps-link {
+    color: var(--vp-c-brand);
+  }
 }
 
 .next-steps-link {
@@ -37,7 +41,7 @@ export default {
   margin-top: 0;
   margin-bottom: 0.75em;
   display: block;
-  color: var(--vp-c-brand);
+  color: var(--vp-c-brand-light);
 }
 
 .next-steps-caption {

--- a/packages/vuepress-theme-vt/global-components/Step.vue
+++ b/packages/vuepress-theme-vt/global-components/Step.vue
@@ -26,7 +26,7 @@ export default {
 }
 
 .next-step:hover {
-  border-color: var(--c-brand);
+  border-color: var(--vp-c-brand);
   transition: border-color 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
 }
 
@@ -37,7 +37,7 @@ export default {
   margin-top: 0;
   margin-bottom: 0.75em;
   display: block;
-  color: var(--c-brand);
+  color: var(--vp-c-brand);
 }
 
 .next-steps-caption {

--- a/packages/vuepress-theme-vt/global-components/Summary.vue
+++ b/packages/vuepress-theme-vt/global-components/Summary.vue
@@ -14,7 +14,7 @@
 .pia-summary-guide {
   opacity: 0.8;
   font-style: italic;
-  color: var(--c-brand);
+  color: var(--vp-c-brand);
 
   &:before {
     content: 'Click to expand'
@@ -26,7 +26,7 @@
   outline: none;
 
   &::marker {
-    color: var(--c-brand);
+    color: var(--vp-c-brand);
     content: '▶️';
     font-weight: bolder;
   }

--- a/packages/vuepress-theme-vt/package.json
+++ b/packages/vuepress-theme-vt/package.json
@@ -24,6 +24,7 @@
     "@vuepress/plugin-nprogress": "1.9.7",
     "@vuepress/shared-utils": "1.9.7",
     "@vuepress/types": "1.9.7",
+    "markdown-it-link-attributes": "2",
     "cheap-watch": "1.0.3",
     "docsearch.js": "^2.5.2",
     "flexsearch": "^0.6.32",

--- a/packages/vuepress-theme-vt/plugins/code-switcher/components/CodeSwitcher.vue
+++ b/packages/vuepress-theme-vt/plugins/code-switcher/components/CodeSwitcher.vue
@@ -169,7 +169,7 @@ $border = 1.5px;
       }
 
       &.active {
-        border: $border solid var(--c-brand-light);
+        border: $border solid var(--vp-c-brand-light);
         background-color: var(--vp-c-bg-soft);
 
         & ~ li {

--- a/packages/vuepress-theme-vt/plugins/fulltext-search/components/SearchBox.vue
+++ b/packages/vuepress-theme-vt/plugins/fulltext-search/components/SearchBox.vue
@@ -329,21 +329,21 @@ function highlight(str, strHighlight) {
     }
 
     &:focus, &:hover {
-      // border: 1px solid var(--vp-c-link);
-      border-color: var(--vp-c-link);
+      // border: 1px solid var(--c-brand);
+      border-color: var(--c-brand);
       transition: border-color 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
     }
 
     &:focus {
       cursor: auto;
-      border-color: var(--vp-c-link);
+      border-color: var(--c-brand);
 
       &::placeholder {
-        color: var(--vp-c-link);
+        color: var(--c-brand);
       }
 
       &~ .search-icon {
-        color: var(--vp-c-link);
+        color: var(--c-brand);
       }
     }
 
@@ -408,7 +408,7 @@ function highlight(str, strHighlight) {
       .parent-page-title {
         color: white;
         font-weight: 500;
-        background-color: var(--vp-c-link);
+        background-color: var(--c-brand);
         padding: 5px;
       }
 

--- a/packages/vuepress-theme-vt/plugins/fulltext-search/components/SearchBox.vue
+++ b/packages/vuepress-theme-vt/plugins/fulltext-search/components/SearchBox.vue
@@ -329,21 +329,21 @@ function highlight(str, strHighlight) {
     }
 
     &:focus, &:hover {
-      // border: 1px solid var(--c-brand);
-      border-color: var(--c-brand);
+      // border: 1px solid var(--vp-c-link);
+      border-color: var(--vp-c-link);
       transition: border-color 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
     }
 
     &:focus {
       cursor: auto;
-      border-color: var(--c-brand);
+      border-color: var(--vp-c-link);
 
       &::placeholder {
-        color: var(--c-brand);
+        color: var(--vp-c-link);
       }
 
       &~ .search-icon {
-        color: var(--c-brand);
+        color: var(--vp-c-link);
       }
     }
 
@@ -408,7 +408,7 @@ function highlight(str, strHighlight) {
       .parent-page-title {
         color: white;
         font-weight: 500;
-        background-color: var(--c-brand);
+        background-color: var(--vp-c-link);
         padding: 5px;
       }
 

--- a/packages/vuepress-theme-vt/plugins/fulltext-search/components/SearchBox.vue
+++ b/packages/vuepress-theme-vt/plugins/fulltext-search/components/SearchBox.vue
@@ -329,21 +329,21 @@ function highlight(str, strHighlight) {
     }
 
     &:focus, &:hover {
-      // border: 1px solid var(--c-brand);
-      border-color: var(--c-brand);
+      // border: 1px solid var(--vp-c-brand);
+      border-color: var(--vp-c-brand);
       transition: border-color 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
     }
 
     &:focus {
       cursor: auto;
-      border-color: var(--c-brand);
+      border-color: var(--vp-c-brand);
 
       &::placeholder {
-        color: var(--c-brand);
+        color: var(--vp-c-brand);
       }
 
       &~ .search-icon {
-        color: var(--c-brand);
+        color: var(--vp-c-brand);
       }
     }
 
@@ -408,7 +408,7 @@ function highlight(str, strHighlight) {
       .parent-page-title {
         color: white;
         font-weight: 500;
-        background-color: var(--c-brand);
+        background-color: var(--vp-c-brand);
         padding: 5px;
       }
 

--- a/packages/vuepress-theme-vt/plugins/fulltext-search/components/SearchBox.vue
+++ b/packages/vuepress-theme-vt/plugins/fulltext-search/components/SearchBox.vue
@@ -435,7 +435,7 @@ function highlight(str, strHighlight) {
             margin: 0 3px;
             padding: 0 3px;
             border-radius: 3px;
-            background: rgba(59, 72, 206, 0.2);
+            background: var(--vp-c-active-link-bg);
           }
 
           border: 1px solid $borderColor;

--- a/packages/vuepress-theme-vt/src/index.ts
+++ b/packages/vuepress-theme-vt/src/index.ts
@@ -13,7 +13,7 @@ export default defineTheme<ThemeConfig>((options, ctx) => {
   const isAlgoliaSearch =
     themeConfig.algolia ||
     Object.keys((siteConfig.locales && themeConfig.locales) || {}).some(
-      base => themeConfig.locales[base].algolia,
+      (base) => themeConfig.locales[base].algolia
     );
 
   const enableSmoothScroll = themeConfig.smoothScroll === true;
@@ -86,8 +86,9 @@ export default defineTheme<ThemeConfig>((options, ctx) => {
       ["smooth-scroll", enableSmoothScroll],
     ],
 
-    extendMarkdown: md => {
+    extendMarkdown: (md) => {
       const markdownItAttrs = require("markdown-it-attrs");
+      const markdownItLinksAttrs = require("markdown-it-link-attributes");
 
       md.use(markdownItAttrs, {
         // optional, these are default options
@@ -95,6 +96,21 @@ export default defineTheme<ThemeConfig>((options, ctx) => {
         rightDelimiter: "}",
         allowedAttributes: [], // empty array = all attributes are allowed
       });
+
+      md.use(markdownItLinksAttrs, [
+        {
+          pattern: /^https?:\/\//,
+          attrs: {
+            class: "link-hover-effect external-link",
+          },
+        },
+        {
+          pattern: /^\.?\//,
+          attrs: {
+            class: "link-hover-effect absolute-link",
+          },
+        },
+      ]);
     },
   };
 });

--- a/packages/vuepress-theme-vt/src/index.ts
+++ b/packages/vuepress-theme-vt/src/index.ts
@@ -13,7 +13,7 @@ export default defineTheme<ThemeConfig>((options, ctx) => {
   const isAlgoliaSearch =
     themeConfig.algolia ||
     Object.keys((siteConfig.locales && themeConfig.locales) || {}).some(
-      (base) => themeConfig.locales[base].algolia
+      base => themeConfig.locales[base].algolia,
     );
 
   const enableSmoothScroll = themeConfig.smoothScroll === true;

--- a/packages/vuepress-theme-vt/styles/index.styl
+++ b/packages/vuepress-theme-vt/styles/index.styl
@@ -89,10 +89,10 @@ a {
 }
 
 a:not(.link-hover-effect) {
-  color: var(--vp-c-link);
+  color: var(--vp-c-brand-light);
 
   &:hover {
-    color: var(--vp-c-link-active);
+    color: var(--vp-c-brand-dark);
   }
 }
 
@@ -100,7 +100,7 @@ a:not(.link-hover-effect) {
   @media (min-width: 768px) {
     a.link-hover-effect {
       text-decoration: none;
-      color: var(--vp-c-link);
+      color: var(--vp-c-brand);
       max-width: 100%;
       position: relative;
       display: inline-block;

--- a/packages/vuepress-theme-vt/styles/index.styl
+++ b/packages/vuepress-theme-vt/styles/index.styl
@@ -89,7 +89,7 @@ a {
 }
 
 a {
-  color: var(--vp-c-brand-light);
+  color: var(--vp-c-brand);
 
   &:hover {
     color: var(--vp-c-brand-dark);
@@ -101,7 +101,7 @@ html:not(.dark) {
     @media (min-width: 768px) {
       a.link-hover-effect {
         text-decoration: none;
-        color: var(--vp-c-brand);
+        color: var(--vp-c-active-link);
         max-width: 100%;
         position: relative;
         display: inline-block;
@@ -116,7 +116,7 @@ html:not(.dark) {
           border-radius: 3px;
           bottom: 10%;
           transition: color 200ms cubic-bezier(0, 0.8, 0.13, 1), top 200ms cubic-bezier(0, 0.8, 0.13, 1);
-          background-color: alpha(#3B48CE, 0.2);
+          background-color: var(--vp-c-active-link-bg);
         }
 
         &:hover {

--- a/packages/vuepress-theme-vt/styles/index.styl
+++ b/packages/vuepress-theme-vt/styles/index.styl
@@ -85,8 +85,46 @@ body {
 }
 
 a {
-  color: var(--c-brand);
   text-decoration: none;
+}
+
+a:not(.link-hover-effect) {
+  color: var(--vp-c-link);
+
+  &:hover {
+    color: var(--vp-c-link-active);
+  }
+}
+
+{$contentClass}.content__default {
+  @media (min-width: 768px) {
+    a.link-hover-effect {
+      text-decoration: none;
+      color: var(--vp-c-link);
+      max-width: 100%;
+      position: relative;
+      display: inline-block;
+      vertical-align: bottom;
+
+      &:after {
+        content: '';
+        position: absolute;
+        top: 60%;
+        left: -0.1em;
+        right: -0.1em;
+        border-radius: 3px;
+        bottom: 10%;
+        transition: color 200ms cubic-bezier(0, 0.8, 0.13, 1), top 200ms cubic-bezier(0, 0.8, 0.13, 1);
+        background-color: alpha(#3B48CE, 0.2);
+      }
+
+      &:hover {
+        &:after {
+          top: 10%;
+        }
+      }
+    }
+  }
 }
 
 p a code {
@@ -236,7 +274,7 @@ table {
 
   .theme-container:not(.no-sidebar) {
     .nav-left-links {
-      padding: 2rem 0rem 2rem calc(var(--vp-doc-padding) - 1.5rem) ;
+      padding: 2rem 0rem 2rem calc(var(--vp-doc-padding) - 1.5rem);
     }
   }
 }

--- a/packages/vuepress-theme-vt/styles/index.styl
+++ b/packages/vuepress-theme-vt/styles/index.styl
@@ -88,7 +88,7 @@ a {
   text-decoration: none;
 }
 
-a:not(.link-hover-effect) {
+a {
   color: var(--vp-c-brand-light);
 
   &:hover {
@@ -96,31 +96,33 @@ a:not(.link-hover-effect) {
   }
 }
 
-{$contentClass}.content__default {
-  @media (min-width: 768px) {
-    a.link-hover-effect {
-      text-decoration: none;
-      color: var(--vp-c-brand);
-      max-width: 100%;
-      position: relative;
-      display: inline-block;
-      vertical-align: bottom;
+html:not(.dark) {
+  {$contentClass}.content__default {
+    @media (min-width: 768px) {
+      a.link-hover-effect {
+        text-decoration: none;
+        color: var(--vp-c-brand);
+        max-width: 100%;
+        position: relative;
+        display: inline-block;
+        vertical-align: bottom;
 
-      &:after {
-        content: '';
-        position: absolute;
-        top: 60%;
-        left: -0.1em;
-        right: -0.1em;
-        border-radius: 3px;
-        bottom: 10%;
-        transition: color 200ms cubic-bezier(0, 0.8, 0.13, 1), top 200ms cubic-bezier(0, 0.8, 0.13, 1);
-        background-color: alpha(#3B48CE, 0.2);
-      }
-
-      &:hover {
         &:after {
-          top: 10%;
+          content: '';
+          position: absolute;
+          top: 60%;
+          left: -0.1em;
+          right: -0.1em;
+          border-radius: 3px;
+          bottom: 10%;
+          transition: color 200ms cubic-bezier(0, 0.8, 0.13, 1), top 200ms cubic-bezier(0, 0.8, 0.13, 1);
+          background-color: alpha(#3B48CE, 0.2);
+        }
+
+        &:hover {
+          &:after {
+            top: 10%;
+          }
         }
       }
     }

--- a/packages/vuepress-theme-vt/styles/theme.styl
+++ b/packages/vuepress-theme-vt/styles/theme.styl
@@ -65,9 +65,20 @@
 }
 
 :root {
+    // light mode
+    --c-brand-primary: #5d57ea;
     --c-brand: #222;
     --c-brand-light: #444;
     --c-brand-dark: #000;
+    --c-active-link: var(--c-brand-primary);
+    --c-active-link-bg: rgba(#5d57ea, 0.2);
+    // dark mode
+    --c-darkmode-brand: #7d79e9;
+    --c-darkmode-brand-light: #9e9cf0;
+    --c-darkmode-brand-dark: var(--c-brand-primary);
+    --c-darkmode-brand-primary: var(--c-brand-primary);
+    --c-darkmode-active-link: var(--c-brand-primary);;
+    --c-darkmode-active-link-bg: rgba(#5d57ea, 0.2);;
 }
 
 :root {
@@ -75,7 +86,7 @@
     --vp-c-bg-soft: var(--vp-c-white-soft);
     --vp-c-bg-header: var(--vp-c-gray-dark-8);
     --vp-c-bg-mute: var(--vp-c-white-mute);
-    --vp-c-bg-code-highlight: var(--vp-c-gray-dark-6);
+    --vp-c-bg-code-primary: var(--vp-c-gray-dark-6);
     --vp-c-divider: var(--vp-c-divider-light-1);
     --vp-c-divider-light: var(--vp-c-divider-light-2);
     --vp-c-divider-inverse: var(--vp-c-divider-dark-1);
@@ -92,8 +103,9 @@
     --vp-c-brand: var(--c-brand);
     --vp-c-brand-light: var(--c-brand-light);
     --vp-c-brand-dark: var(--c-brand-dark);
-    --vp-c-brand-highlight: var(--c-brand-dark);
     --vp-c-page-edit-text: var(--vp-c-black-pure);
+    --vp-c-active-link: var(--c-active-link);
+    --vp-c-active-link-bg: var(--c-active-link-bg);
 }
 
 .dark {
@@ -101,7 +113,7 @@
     --vp-c-bg-soft: var(--vp-c-black-soft);
     --vp-c-bg-header: var(--vp-c-black);
     --vp-c-bg-mute: var(--vp-c-black-mute);
-    --vp-c-bg-code-highlight: var(--vp-c-gray-dark-7);
+    --vp-c-bg-code-primary: var(--vp-c-gray-dark-7);
     --vp-c-divider: var(--vp-c-divider-dark-1);
     --vp-c-divider-light: var(--vp-c-divider-dark-2);
     --vp-c-divider-inverse: var(--vp-c-divider-light-1);
@@ -115,11 +127,12 @@
     --vp-c-text-inverse-2: var(--vp-c-text-light-2);
     --vp-c-text-inverse-3: var(--vp-c-text-light-3);
     --vp-c-text-inverse-4: var(--vp-c-text-light-4);
-    --vp-c-brand: var(--vp-c-blue-light);
-    --vp-c-brand-light: var(--vp-c-blue-lighter);
-    --vp-c-brand-dark: var(--vp-c-blue);
-    --vp-c-brand-highlight: var(--vp-c-brand-light);
+    --vp-c-brand: var(--c-darkmode-brand);
+    --vp-c-brand-light: var(--c-darkmode-brand-light);
+    --vp-c-brand-dark: var(--c-darkmode-brand-dark);
     --vp-c-page-edit-text: var(--vp-c-white);
+    --vp-c-active-link: var(--c-darkmode-active-link);
+    --vp-c-active-link-bg: var(--c-darkmode-active-link-bg);
 }
 
 :root {

--- a/packages/vuepress-theme-vt/styles/theme.styl
+++ b/packages/vuepress-theme-vt/styles/theme.styl
@@ -65,9 +65,11 @@
 }
 
 :root {
-    --c-brand: #5c6ac4;
-    --c-brand-light: #7c87cf;
-    --c-brand-dark: #3d4ba9;
+    --c-brand: #222;
+    --c-brand-light: #444;
+    --c-brand-dark: #000;
+    --c-link: #4389d8;
+    --c-link-active: #0969da;
 }
 
 :root {
@@ -94,6 +96,8 @@
     --vp-c-brand-dark: var(--c-brand-dark);
     --vp-c-brand-highlight: var(--c-brand-dark);
     --vp-c-page-edit-text: var(--vp-c-black-pure);
+    --vp-c-link: var(--c-link);
+    --vp-c-link-ative: var(--c-link-active);
 }
 
 .dark {
@@ -117,6 +121,8 @@
     --vp-c-text-inverse-4: var(--vp-c-text-light-4);
     --vp-c-brand-highlight: var(--vp-c-brand-light);
     --vp-c-page-edit-text: var(--vp-c-white);
+    --vp-c-link: var(--c-link);
+    --vp-c-link-ative: var(--c-link-active);
 }
 
 :root {

--- a/packages/vuepress-theme-vt/styles/theme.styl
+++ b/packages/vuepress-theme-vt/styles/theme.styl
@@ -115,9 +115,9 @@
     --vp-c-text-inverse-2: var(--vp-c-text-light-2);
     --vp-c-text-inverse-3: var(--vp-c-text-light-3);
     --vp-c-text-inverse-4: var(--vp-c-text-light-4);
-    --vp-c-brand: var(--vp-c-blue);
-    --vp-c-brand-light: var(--vp-c-blue-light);
-    --vp-c-brand-dark: var(--vp-c-blue-dark);
+    --vp-c-brand: var(--vp-c-blue-light);
+    --vp-c-brand-light: var(--vp-c-blue-lighter);
+    --vp-c-brand-dark: var(--vp-c-blue);
     --vp-c-brand-highlight: var(--vp-c-brand-light);
     --vp-c-page-edit-text: var(--vp-c-white);
 }

--- a/packages/vuepress-theme-vt/styles/theme.styl
+++ b/packages/vuepress-theme-vt/styles/theme.styl
@@ -68,8 +68,6 @@
     --c-brand: #222;
     --c-brand-light: #444;
     --c-brand-dark: #000;
-    --c-link: #4389d8;
-    --c-link-active: #0969da;
 }
 
 :root {
@@ -96,8 +94,6 @@
     --vp-c-brand-dark: var(--c-brand-dark);
     --vp-c-brand-highlight: var(--c-brand-dark);
     --vp-c-page-edit-text: var(--vp-c-black-pure);
-    --vp-c-link: var(--c-link);
-    --vp-c-link-ative: var(--c-link-active);
 }
 
 .dark {
@@ -119,10 +115,11 @@
     --vp-c-text-inverse-2: var(--vp-c-text-light-2);
     --vp-c-text-inverse-3: var(--vp-c-text-light-3);
     --vp-c-text-inverse-4: var(--vp-c-text-light-4);
+    --vp-c-brand: var(--vp-c-blue);
+    --vp-c-brand-light: var(--vp-c-blue-light);
+    --vp-c-brand-dark: var(--vp-c-blue-dark);
     --vp-c-brand-highlight: var(--vp-c-brand-light);
     --vp-c-page-edit-text: var(--vp-c-white);
-    --vp-c-link: var(--c-link);
-    --vp-c-link-ative: var(--c-link-active);
 }
 
 :root {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: 5.3
+lockfileVersion: 5.4
 
 importers:
 
@@ -20,7 +20,7 @@ importers:
       jest-cli: 27.3.1
       jest-serializer-path: 0.1.15
       lerna: 4.0.0
-      ts-jest: 27.0.7_@types+jest@27.0.0+jest@27.3.1
+      ts-jest: 27.0.7_drgbl6usjogxnjhdw42vd22ndu
 
   packages/docs:
     specifiers:
@@ -120,7 +120,7 @@ importers:
       stylus: 0.54.8
       stylus-loader: 3.0.2_stylus@0.54.8
       vue: 2.6.14
-      vue-router: 3.5.3
+      vue-router: 3.5.3_vue@2.6.14
       vuepress-plugin-container: 2.1.5
       vuepress-plugin-smooth-scroll: 0.0.3
     devDependencies:
@@ -3023,7 +3023,7 @@ packages:
       '@vuepress/shared-utils': 1.9.7
       '@vuepress/types': 1.9.7
       autoprefixer: 9.8.8
-      babel-loader: 8.2.3_174483de130731162278521ff93b7183
+      babel-loader: 8.2.3_c5cihxqta4yrmitykip7so3rqm
       bundle-require: 2.1.8_esbuild@0.14.7
       cache-loader: 3.0.1_webpack@4.46.0
       chokidar: 2.1.8
@@ -3044,8 +3044,8 @@ packages:
       toml: 3.0.0
       url-loader: 1.1.2_webpack@4.46.0
       vue: 2.6.14
-      vue-loader: 15.9.8_a021309c4954b2e3e3b6c3a6e1323de2
-      vue-router: 3.5.3
+      vue-loader: 15.9.8_uaqtbhcjkszohy5wyotocmr54i
+      vue-router: 3.5.3_vue@2.6.14
       vue-server-renderer: 2.6.14
       vue-template-compiler: 2.6.14
       vuepress-html-webpack-plugin: 3.2.0_webpack@4.46.0
@@ -3834,7 +3834,7 @@ packages:
       - supports-color
     dev: true
 
-  /babel-loader/8.2.3_174483de130731162278521ff93b7183:
+  /babel-loader/8.2.3_c5cihxqta4yrmitykip7so3rqm:
     resolution: {integrity: sha512-n4Zeta8NC3QAsuyiizu0GkmRcQ6clkV9WFUnUf1iXP//IeSKbWjofW3UHyZVwlOB4y039YQKefawyTn64Zwbuw==}
     engines: {node: '>= 8.9'}
     peerDependencies:
@@ -4877,7 +4877,7 @@ packages:
       lodash: ^4.17.20
       marko: ^3.14.4
       mote: ^0.2.0
-      mustache: ^4.0.1
+      mustache: ^3.0.0
       nunjucks: ^3.2.2
       plates: ~0.4.11
       pug: ^3.0.0
@@ -5180,8 +5180,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
-      is-text-path: 1.0.1
       JSONStream: 1.3.5
+      is-text-path: 1.0.1
       lodash: 4.17.21
       meow: 8.1.2
       split2: 3.2.2
@@ -7478,7 +7478,7 @@ packages:
       - supports-color
     dev: true
 
-  /http-proxy-middleware/0.19.1_debug@4.3.3+supports-color@6.1.0:
+  /http-proxy-middleware/0.19.1_ww346azdyxua6tt4dpauz7tfuu:
     resolution: {integrity: sha512-yHYTgWMQO8VvwNS22eLLloAkvungsKdKTLO8AJlftYIKNfJr3GK3zK0ZCfzDDGUBttdGc8xFy1mCitvNKQtC3Q==}
     engines: {node: '>=4.0.0'}
     dependencies:
@@ -12845,7 +12845,7 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /ts-jest/27.0.7_@types+jest@27.0.0+jest@27.3.1:
+  /ts-jest/27.0.7_drgbl6usjogxnjhdw42vd22ndu:
     resolution: {integrity: sha512-O41shibMqzdafpuP+CkrOL7ykbmLh+FqQrXEmV9CydQ5JBk0Sj0uAEF5TNNe94fZWKm3yYvWa/IbyV4Yg1zK2Q==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     hasBin: true
@@ -13265,7 +13265,7 @@ packages:
     resolution: {integrity: sha512-BXq3jwIagosjgNVae6tkHzzIk6a8MHFtzAdwhnV5VlvPTFxDCvIttgSiHWjdGoTJvXtmRu5HacExfdarRcFhog==}
     dev: true
 
-  /vue-loader/15.9.8_a021309c4954b2e3e3b6c3a6e1323de2:
+  /vue-loader/15.9.8_uaqtbhcjkszohy5wyotocmr54i:
     resolution: {integrity: sha512-GwSkxPrihfLR69/dSV3+5CdMQ0D+jXg8Ma1S4nQXKJAznYFX14vHdc/NetQc34Dw+rBbIJyP7JOuVb9Fhprvog==}
     peerDependencies:
       '@vue/compiler-sfc': ^3.0.8
@@ -13346,8 +13346,12 @@ packages:
       - whiskers
     dev: true
 
-  /vue-router/3.5.3:
+  /vue-router/3.5.3_vue@2.6.14:
     resolution: {integrity: sha512-FUlILrW3DGitS2h+Xaw8aRNvGTwtuaxrRkNSHWTizOfLUie7wuYwezeZ50iflRn8YPV5kxmU2LQuu3nM/b3Zsg==}
+    peerDependencies:
+      vue: ^2
+    dependencies:
+      vue: 2.6.14
 
   /vue-server-renderer/2.6.14:
     resolution: {integrity: sha512-HifYRa/LW7cKywg9gd4ZtvtRuBlstQBao5ZCWlg40fyB4OPoGfEXAzxb0emSLv4pBDOHYx0UjpqvxpiQFEuoLA==}
@@ -13613,7 +13617,7 @@ packages:
       del: 4.1.1
       express: 4.17.2_supports-color@6.1.0
       html-entities: 1.4.0
-      http-proxy-middleware: 0.19.1_debug@4.3.3+supports-color@6.1.0
+      http-proxy-middleware: 0.19.1_ww346azdyxua6tt4dpauz7tfuu
       import-local: 2.0.0
       internal-ip: 4.3.0
       ip: 1.1.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: 5.4
+lockfileVersion: 5.3
 
 importers:
 
@@ -20,7 +20,7 @@ importers:
       jest-cli: 27.3.1
       jest-serializer-path: 0.1.15
       lerna: 4.0.0
-      ts-jest: 27.0.7_drgbl6usjogxnjhdw42vd22ndu
+      ts-jest: 27.0.7_@types+jest@27.0.0+jest@27.3.1
 
   packages/docs:
     specifiers:
@@ -92,6 +92,7 @@ importers:
       inquirer: 7.3.3
       lodash: ^4.17.15
       markdown-it-attrs: ^2
+      markdown-it-link-attributes: '2'
       node-google-translate-skidz: 1.1.2
       prism-themes: 1.9.0
       stylus: ^0.54.8
@@ -113,12 +114,13 @@ importers:
       inquirer: 7.3.3
       lodash: 4.17.21
       markdown-it-attrs: 2.4.1
+      markdown-it-link-attributes: 2.1.0
       node-google-translate-skidz: 1.1.2
       prism-themes: 1.9.0
       stylus: 0.54.8
       stylus-loader: 3.0.2_stylus@0.54.8
       vue: 2.6.14
-      vue-router: 3.5.3_vue@2.6.14
+      vue-router: 3.5.3
       vuepress-plugin-container: 2.1.5
       vuepress-plugin-smooth-scroll: 0.0.3
     devDependencies:
@@ -3021,7 +3023,7 @@ packages:
       '@vuepress/shared-utils': 1.9.7
       '@vuepress/types': 1.9.7
       autoprefixer: 9.8.8
-      babel-loader: 8.2.3_c5cihxqta4yrmitykip7so3rqm
+      babel-loader: 8.2.3_174483de130731162278521ff93b7183
       bundle-require: 2.1.8_esbuild@0.14.7
       cache-loader: 3.0.1_webpack@4.46.0
       chokidar: 2.1.8
@@ -3042,8 +3044,8 @@ packages:
       toml: 3.0.0
       url-loader: 1.1.2_webpack@4.46.0
       vue: 2.6.14
-      vue-loader: 15.9.8_uaqtbhcjkszohy5wyotocmr54i
-      vue-router: 3.5.3_vue@2.6.14
+      vue-loader: 15.9.8_a021309c4954b2e3e3b6c3a6e1323de2
+      vue-router: 3.5.3
       vue-server-renderer: 2.6.14
       vue-template-compiler: 2.6.14
       vuepress-html-webpack-plugin: 3.2.0_webpack@4.46.0
@@ -3832,7 +3834,7 @@ packages:
       - supports-color
     dev: true
 
-  /babel-loader/8.2.3_c5cihxqta4yrmitykip7so3rqm:
+  /babel-loader/8.2.3_174483de130731162278521ff93b7183:
     resolution: {integrity: sha512-n4Zeta8NC3QAsuyiizu0GkmRcQ6clkV9WFUnUf1iXP//IeSKbWjofW3UHyZVwlOB4y039YQKefawyTn64Zwbuw==}
     engines: {node: '>= 8.9'}
     peerDependencies:
@@ -4875,7 +4877,7 @@ packages:
       lodash: ^4.17.20
       marko: ^3.14.4
       mote: ^0.2.0
-      mustache: ^3.0.0
+      mustache: ^4.0.1
       nunjucks: ^3.2.2
       plates: ~0.4.11
       pug: ^3.0.0
@@ -5178,8 +5180,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
-      JSONStream: 1.3.5
       is-text-path: 1.0.1
+      JSONStream: 1.3.5
       lodash: 4.17.21
       meow: 8.1.2
       split2: 3.2.2
@@ -7476,7 +7478,7 @@ packages:
       - supports-color
     dev: true
 
-  /http-proxy-middleware/0.19.1_ww346azdyxua6tt4dpauz7tfuu:
+  /http-proxy-middleware/0.19.1_debug@4.3.3+supports-color@6.1.0:
     resolution: {integrity: sha512-yHYTgWMQO8VvwNS22eLLloAkvungsKdKTLO8AJlftYIKNfJr3GK3zK0ZCfzDDGUBttdGc8xFy1mCitvNKQtC3Q==}
     engines: {node: '>=4.0.0'}
     dependencies:
@@ -9275,6 +9277,10 @@ packages:
   /markdown-it-emoji/1.4.0:
     resolution: {integrity: sha1-m+4OmpkKljupbfaYDE/dsF37Tcw=}
     dev: true
+
+  /markdown-it-link-attributes/2.1.0:
+    resolution: {integrity: sha512-NclmOF52k57idAZI93PREbPKbKPFyafwoJncWW9dKpkYGbO26oJGHa4bUoU27Lk8TeWLbPEzuKFyQGwuB2NbdA==}
+    dev: false
 
   /markdown-it-table-of-contents/0.4.4:
     resolution: {integrity: sha512-TAIHTHPwa9+ltKvKPWulm/beozQU41Ab+FIefRaQV1NRnpzwcV9QOe6wXQS5WLivm5Q/nlo0rl6laGkMDZE7Gw==}
@@ -12839,7 +12845,7 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /ts-jest/27.0.7_drgbl6usjogxnjhdw42vd22ndu:
+  /ts-jest/27.0.7_@types+jest@27.0.0+jest@27.3.1:
     resolution: {integrity: sha512-O41shibMqzdafpuP+CkrOL7ykbmLh+FqQrXEmV9CydQ5JBk0Sj0uAEF5TNNe94fZWKm3yYvWa/IbyV4Yg1zK2Q==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     hasBin: true
@@ -13259,7 +13265,7 @@ packages:
     resolution: {integrity: sha512-BXq3jwIagosjgNVae6tkHzzIk6a8MHFtzAdwhnV5VlvPTFxDCvIttgSiHWjdGoTJvXtmRu5HacExfdarRcFhog==}
     dev: true
 
-  /vue-loader/15.9.8_uaqtbhcjkszohy5wyotocmr54i:
+  /vue-loader/15.9.8_a021309c4954b2e3e3b6c3a6e1323de2:
     resolution: {integrity: sha512-GwSkxPrihfLR69/dSV3+5CdMQ0D+jXg8Ma1S4nQXKJAznYFX14vHdc/NetQc34Dw+rBbIJyP7JOuVb9Fhprvog==}
     peerDependencies:
       '@vue/compiler-sfc': ^3.0.8
@@ -13340,12 +13346,8 @@ packages:
       - whiskers
     dev: true
 
-  /vue-router/3.5.3_vue@2.6.14:
+  /vue-router/3.5.3:
     resolution: {integrity: sha512-FUlILrW3DGitS2h+Xaw8aRNvGTwtuaxrRkNSHWTizOfLUie7wuYwezeZ50iflRn8YPV5kxmU2LQuu3nM/b3Zsg==}
-    peerDependencies:
-      vue: ^2
-    dependencies:
-      vue: 2.6.14
 
   /vue-server-renderer/2.6.14:
     resolution: {integrity: sha512-HifYRa/LW7cKywg9gd4ZtvtRuBlstQBao5ZCWlg40fyB4OPoGfEXAzxb0emSLv4pBDOHYx0UjpqvxpiQFEuoLA==}
@@ -13611,7 +13613,7 @@ packages:
       del: 4.1.1
       express: 4.17.2_supports-color@6.1.0
       html-entities: 1.4.0
-      http-proxy-middleware: 0.19.1_ww346azdyxua6tt4dpauz7tfuu
+      http-proxy-middleware: 0.19.1_debug@4.3.3+supports-color@6.1.0
       import-local: 2.0.0
       internal-ip: 4.3.0
       ip: 1.1.5


### PR DESCRIPTION
# Summary

1. Fixed dark mode link style issue;
2. Introduce fine-grained link color CSS variables;
3. Introduce link hover effect (disabled at dark mode by default);
4. Correct all color usage (Using `--vp-c-*` instead of `--c-*`);